### PR TITLE
feat: Add vercel-build script to fix deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,16 @@ For deploying to Vercel or any other CI/CD environment, it is highly recommended
 **Recommended Vercel Build Command:**
 
 ```
-npm ci && npm run build
+npm ci && npm run vercel-build
 ```
 
-This can be set in your Vercel project's "Build & Development Settings".
+This can be set in your Vercel project's "Build & Development Settings". A `vercel-build` script is included in `package.json` and is referenced in `vercel.json`. This ensures a consistent build command for Vercel deployments.
 
 ## Available Scripts
 
 - `npm run dev`: Starts the development server.
 - `npm run build`: Creates a production-ready build of the application.
+- `npm run vercel-build`: A dedicated script for Vercel builds. It is aliased to `npm run build`.
 - `npm run start`: Starts the production server after a build.
 - `npm run lint`: Runs ESLint to check for code quality issues.
 - `npm run db:push`: Applies schema changes directly to the database (ideal for development).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,9 +2269,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.13.tgz",
-      "integrity": "sha512-7s16KR8io8nIBWQyCYhmFhd+ebIzb9VKTzki+wOJXHTxTnV6+mFGH3+Jwn1zoKaY9/H9T/0BcKCZnzXljPnpSQ==",
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.14.tgz",
+      "integrity": "sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "vercel-build": "next build",
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate",


### PR DESCRIPTION
Adds the `vercel-build` script to `package.json` to resolve the Vercel deployment failure.

This change also includes:
- Regeneration of the `package-lock.json` file.
- Updates to the `README.md` to document the new script and its usage in the Vercel build command.